### PR TITLE
Add .inl as valid C++ header type

### DIFF
--- a/clang/lib/Driver/Types.cpp
+++ b/clang/lib/Driver/Types.cpp
@@ -237,6 +237,7 @@ types::ID types::lookupTypeForExtension(llvm::StringRef Ext) {
            .Case("cp", TY_CXX)
            .Case("cu", TY_CUDA)
            .Case("hh", TY_CXXHeader)
+           .Case("inl", TY_CXXHeader)
            .Case("ii", TY_PP_CXX)
            .Case("ll", TY_LLVM_IR)
            .Case("mi", TY_PP_ObjC)


### PR DESCRIPTION
`clangd` doesn't consider `.inl` a valid C++ source [issue](https://github.com/clangd/clangd/issues/16#issuecomment-512942589) this pull request adds support for that.

Until the `export` keyword is supported by compilers [export keyword](https://stackoverflow.com/questions/5416872/using-export-keyword-with-templates) a common way of keeping header files cleaner is to move template definitions into `.inl` files. This seems to be a common practice. Some evidence of it being commonly used for this purpose.[here](https://www.randygaul.net/2015/01/31/c-keyword-inline-and-inl-files/), [here](https://drake.mit.edu/cxx_inl.html), [here](https://www.codeproject.com/Articles/48575/How-to-define-a-template-class-in-a-h-file-and-imp) and [here](https://stackoverflow.com/questions/31949731/very-confused-on-template-inl-file) even [brdf-loader](https://github.com/rgl-epfl/brdf-loader)

Some other ways of separating definitions is [this](https://github.com/RobotLocomotion/drake/issues/3141) where they say you should use .inl or .impl or -inl.h or -impl.h and this might be ok but then things like projectile can't find it because that only works with extensions.

One caveat of this is, the above methods of using `.inl` files means its not a complete translation unit so `clangd` still can't fully compile it so one has to add `#include "header.hpp"` at the top of `.inl` files to make it work but thats not a big deal.
